### PR TITLE
Do not escape path in upload

### DIFF
--- a/lib/dropbox-api/client/files.rb
+++ b/lib/dropbox-api/client/files.rb
@@ -17,7 +17,6 @@ module Dropbox
         end
 
         def upload(path, data, options = {})
-          path     = Dropbox::API::Util.escape(path)
           url      = ['', "files", "upload"].compact.join('/')
           api_args = { :path => path, :mode => "overwrite" }.merge(options)
           response = connection.post_raw(:content, url, data, {


### PR DESCRIPTION
Do not escape path. Is not necessary and leads to weird names within dropbox i.e. test%20file.txt